### PR TITLE
Bump the Spring Boot version to 2.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+    agent {
+        node {
+            label 'second_maven_pod'}
+    }
+   stages {
+        stage('Check Maven') {
+          steps {
+              container('maven') {
+                sh 'mvn --version'
+                sh 'ls -l /root/.m2/repository'
+              }
+          }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,14 @@ pipeline {
         node {
             label 'second_maven_pod'}
     }
-   stages {
+    stages {
         stage('Check Maven') {
-          steps {
-              container('maven') {
-                sh 'mvn --version'
-                sh 'ls -l /root/.m2/repository'
-              }
-          }
+            steps {
+                container('maven') {
+                    sh 'mvn --version'
+                    sh 'ls -l /root/.m2/repository'
+                }
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         node {
-            label 'second_maven_pod'}
+            label 'maven_pod'}
     }
     stages {
         stage('Check Maven') {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.oufti</groupId>
   <artifactId>demoapp</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.2.RELEASE</version>
+    <version>2.2.0.RELEASE</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
Upgraded the demo app to a more recent version of Spring Boot (2.2.0, released in October 2019). This induces a version bump of the DemoApp to 1.2.0 to reflect the change.